### PR TITLE
56-frontend-fix_gradle_build

### DIFF
--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -1,3 +1,12 @@
+def envFile = project.rootProject.file('../.env')
+def Properties envVariables
+if (envFile.exists()) {
+    envVariables = new Properties()
+    envFile.withInputStream { stream ->
+        envVariables.load(stream)
+    }
+}
+
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
@@ -30,7 +39,7 @@ allprojects {
                 // This should always be `mapbox` (not your username).
                 username = 'mapbox'
                 // Use the secret token you stored in gradle.properties as the password
-                password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ""
+                password = project.ext.has('MAPBOX_DOWNLOADS_TOKEN') ? project.ext.get('MAPBOX_DOWNLOADS_TOKEN') : envVariables.getProperty('MAPBOX_SECRET_TOKEN')
             }
         }
     }


### PR DESCRIPTION
Make the correct configuration for loading the mapbox token from .env when installing the SDK