### PR TITLE
#117 backend swagger UI authorization

### DIFF
--- a/backend/src/attraction/routes/router.py
+++ b/backend/src/attraction/routes/router.py
@@ -21,63 +21,57 @@ geo_service = MapsCoService()
 _attraction_service = AttractionService(attraction_repo, cache_storage, cloud_storage, geo_service)
 
 
-@router.get("/all")
+@router.get("/all", dependencies=[Depends(verify_jwt)])
 def get_all_attractions(
-        db: Session = Depends(get_db), is_token_valid: bool = Depends(verify_jwt)
+        db: Session = Depends(get_db)
 ) -> list[AttractionSchema]:
     return _attraction_service.get_all_attractions(db)
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(verify_jwt)])
 def get_attractions(
         filters: AttractionFilters = Depends(),
-        db: Session = Depends(get_db),
-        is_token_valid: bool = Depends(verify_jwt),
+        db: Session = Depends(get_db)
 ) -> list[AttractionSchema]:
     return _attraction_service.get_attractions(db, filters)
 
 
 @router.get("/{attraction_id}")
-def get_attraction_by_id(
+async def get_attraction_by_id(
         attraction_id: int,
-        db: Session = Depends(get_db),
-        is_token_valid: bool = Depends(verify_jwt),
+        db: Session = Depends(get_db)
 ) -> AttractionSchema:
     return _attraction_service.get_attraction_by_id(db, attraction_id)
 
 
-@router.post("/create")
+@router.post("/create", dependencies=[Depends(verify_jwt)])
 def create_attraction(
         attraction: AttractionSchema,
-        db: Session = Depends(get_db),
-        is_token_valid: bool = Depends(verify_jwt),
+        db: Session = Depends(get_db)
 ) -> Response:
     return _attraction_service.create_attraction(db, attraction)
 
 
-@router.get("/{attraction_id}/images")
+@router.get("/{attraction_id}/images", dependencies=[Depends(verify_jwt)])
 def get_attraction_images(
         attraction_id: int,
-        db: Session = Depends(get_db),
-        is_token_valid: bool = Depends(verify_jwt),
+        db: Session = Depends(get_db)
 ) -> AttractionImages:
     return _attraction_service.get_attraction_images(db, attraction_id)
 
 
-@router.patch("/{attraction_id}/update")
+@router.patch("/{attraction_id}/update", dependencies=[Depends(verify_jwt)])
 def update_attraction(
         attraction_id: int,
         updated_attraction: AttractionSchema,
-        db: Session = Depends(get_db),
-        is_token_valid: bool = Depends(verify_jwt),
+        db: Session = Depends(get_db)
 ) -> AttractionSchema:
     return _attraction_service.update_attraction(db, attraction_id, updated_attraction)
 
 
-@router.delete("/{attraction_id}/delete")
+@router.delete("/{attraction_id}/delete", dependencies=[Depends(verify_jwt)])
 def delete_attraction(
         attraction_id: int,
-        db: Session = Depends(get_db),
-        is_token_valid: bool = Depends(verify_jwt),
+        db: Session = Depends(get_db)
 ) -> Response:
     return _attraction_service.delete_attraction(db, attraction_id)

--- a/backend/src/core/interceptors/auth_interceptor.py
+++ b/backend/src/core/interceptors/auth_interceptor.py
@@ -1,8 +1,9 @@
 import logging
-from typing import Optional
+from typing import Annotated, Optional
 from uuid import UUID
 
 from fastapi import Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from src.auth.utils import (
     decode_jwt_token,
@@ -11,11 +12,13 @@ from src.auth.utils import (
 
 logger = logging.getLogger(__name__)
 
+security = HTTPBearer()
+
 
 def verify_jwt(
-    get_token: str = Depends(get_token_from_request),
+    auth: Annotated[HTTPAuthorizationCredentials, Depends(security)]
 ) -> bool:
-    token = decode_jwt_token(token=get_token)
+    token = decode_jwt_token(token=auth.credentials)
     if token:
         return True
     return False

--- a/backend/src/core/interceptors/auth_interceptor.py
+++ b/backend/src/core/interceptors/auth_interceptor.py
@@ -17,11 +17,8 @@ security = HTTPBearer()
 
 def verify_jwt(
     auth: Annotated[HTTPAuthorizationCredentials, Depends(security)]
-) -> bool:
-    token = decode_jwt_token(token=auth.credentials)
-    if token:
-        return True
-    return False
+) -> None:
+    decode_jwt_token(token=auth.credentials)
 
 
 def get_user_id(

--- a/backend/src/file/routers/media_router.py
+++ b/backend/src/file/routers/media_router.py
@@ -24,14 +24,13 @@ cloud_storage = CloudStorage()
 media_service = MediaService(repository=media_repository, storage=cloud_storage)
 
 
-@media_router.post("/create")
+@media_router.post("/create", dependencies=[Depends(verify_jwt)])
 def create_media(
     file: UploadFile = File(...),
     attraction_id: Optional[int] = Form(None),
     review_id: Optional[uuid.UUID] = Form(None),
     comment_id: Optional[uuid.UUID] = Form(None),
-    db: Session = Depends(get_db),
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Session = Depends(get_db)
 ) -> Response:
     media_create = MediaCreate(
         attraction_id=attraction_id,
@@ -43,71 +42,64 @@ def create_media(
     return media_service.create_media(db, media_create, file)
 
 
-@media_router.get("/{media_id}")
+@media_router.get("/{media_id}", dependencies=[Depends(verify_jwt)])
 def get_media(
     media_id: str,
-    db: Session = Depends(get_db),
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Session = Depends(get_db)
 ) -> List[MediaRead]:
     return media_service.get_media_obj(media_id, db)
 
 
-@media_router.get("/by-attraction/{attraction_id}")
+@media_router.get("/by-attraction/{attraction_id}", dependencies=[Depends(verify_jwt)])
 def get_media_by_attraction(
     attraction_id: int,
-    db: Session = Depends(get_db),
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Session = Depends(get_db)
 ) -> List[MediaRead]:
     return media_service.get_media_by_reference(
         db, MediaReference(attraction_id=attraction_id)
     )
 
 
-@media_router.get("/by-comment/{comment_id}")
+@media_router.get("/by-comment/{comment_id}", dependencies=[Depends(verify_jwt)])
 def get_media_by_comment(
     comment_id: str,
-    db: Session = Depends(get_db),
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Session = Depends(get_db)
 ) -> List[MediaRead]:
     return media_service.get_media_by_reference(
         db, MediaReference(comment_id=comment_id)
     )
 
 
-@media_router.get("/by-review/{review_id}")
+@media_router.get("/by-review/{review_id}", dependencies=[Depends(verify_jwt)])
 def get_media_by_review(
     review_id: str,
-    db: Session = Depends(get_db),
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Session = Depends(get_db)
 ) -> List[MediaRead]:
     return media_service.get_media_by_reference(db, MediaReference(review_id=review_id))
 
 
-@media_router.patch("/{media_id}/update")
+@media_router.patch("/{media_id}/update", dependencies=[Depends(verify_jwt)])
 def update_media(
     media_id: str,
     media_update: MediaUpdate,
-    db: Session = Depends(get_db),
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Session = Depends(get_db)
 ) -> MediaRead:
     return media_service.update_media(db, media_id, media_update)
 
 
-@media_router.delete("/{media_id}/delete")
+@media_router.delete("/{media_id}/delete", dependencies=[Depends(verify_jwt)])
 def delete_media(
     media_id: str,
-    db: Session = Depends(get_db),
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Session = Depends(get_db)
 ) -> Response:
     return media_service.delete_media(db, media_id)
 
 
-@media_router.get("/{bucket_name}/{object_id}/{filename}")
+@media_router.get("/{bucket_name}/{object_id}/{filename}", dependencies=[Depends(verify_jwt)])
 def open_media_from_cloud_storage(
     bucket_name: str,
     object_id: int | str | uuid.UUID,
-    filename: str,
-    is_token_valid: bool = Depends(verify_jwt),
+    filename: str
 ):
     return media_service.get_media_file(
         MediaFile(
@@ -118,9 +110,9 @@ def open_media_from_cloud_storage(
     )
 
 
-@media_router.get("/{bucket_name}/{filename}")
+@media_router.get("/{bucket_name}/{filename}", dependencies=[Depends(verify_jwt)])
 def open_default_media_from_cloud_storage(
-    bucket_name: str, filename: str, is_token_valid: bool = Depends(verify_jwt)
+    bucket_name: str, filename: str
 ):
     return media_service.get_media_file(
         MediaFile(bucket_name=bucket_name, file_name=filename)

--- a/backend/src/threads/routes/router.py
+++ b/backend/src/threads/routes/router.py
@@ -37,66 +37,60 @@ def create_thread(
     return review_service.create(user_id=user_id, thread=thread, db=db)
 
 
-@threads_router.get("/{review_id}")
+@threads_router.get("/{review_id}", dependencies=[Depends(verify_jwt)])
 def get_thread(
     review_id: uuid.UUID,
-    db: Annotated[Session, Depends(get_db)],
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Annotated[Session, Depends(get_db)]
 ) -> ReviewSchema:
     return review_service.get_thread_by_id(thread_id=review_id, db=db)
 
 
-@threads_router.delete("/{review_id}")
+@threads_router.delete("/{review_id}", dependencies=[Depends(verify_jwt)])
 def delete_thread(
     review_id: uuid.UUID,
-    db: Annotated[Session, Depends(get_db)],
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Annotated[Session, Depends(get_db)]
 ) -> Response:
     return review_service.delete_thread(db=db, review_id=review_id)
 
 
-@threads_router.delete("/comment/{comment_id}")
+@threads_router.delete("/comment/{comment_id}", dependencies=[Depends(verify_jwt)])
 def delete_comment(
     comment_id: uuid.UUID,
-    db: Annotated[Session, Depends(get_db)],
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Annotated[Session, Depends(get_db)]
 ) -> Response:
     return comment_service.delete_comment(db=db, comment_id=comment_id)
 
 
-@threads_router.patch("/{review_id}")
+@threads_router.patch("/{review_id}", dependencies=[Depends(verify_jwt)])
 def update_thread(
     review_id: uuid.UUID,
     review: ReviewUpdate,
-    db: Annotated[Session, Depends(get_db)],
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Annotated[Session, Depends(get_db)]
 ) -> ReviewSchema:
     return review_service.update_thread(
         db=db, review_id=review_id, updated_review=review
     )
 
 
-@threads_router.patch("/comment/{comment_id}")
+@threads_router.patch("/comment/{comment_id}", dependencies=[Depends(verify_jwt)])
 def update_comment(
     comment_id: uuid.UUID,
     comment: CommentUpdate,
-    db: Annotated[Session, Depends(get_db)],
-    is_token_valid: bool = Depends(verify_jwt),
+    db: Annotated[Session, Depends(get_db)]
 ) -> CommentSchema:
     return comment_service.update_comment(
         db=db, comment_id=comment_id, updated_comment=comment
     )
 
 
-@threads_router.get("/attraction/{attraction_id}")
+@threads_router.get("/attraction/{attraction_id}", dependencies=[Depends(verify_jwt)])
 def get_threads_attraction(
     db: Annotated[Session, Depends(get_db)],
     attraction_id: int | str,
     sort_by: Optional[str] = None,  # 'rating', 'price', 'time_spent'
     rating: Optional[int] = None,
     price: Optional[int] = None,
-    time_spent: Optional[int] = None,
-    is_token_valid: bool = Depends(verify_jwt),
+    time_spent: Optional[int] = None
 ) -> list[ReviewSchema]:
     return review_service.get_threads_attraction_filtered_sorted(
         db=db,


### PR DESCRIPTION
1. Add 'Authorize' button to Swagger UI by leveraging built-in FastAPI token interceptors so we can access locked endpoints that require Bearer token.
    https://fastapi.tiangolo.com/reference/security/#fastapi.security.HTTPBearer


2.  Refactored the verification of JWT Tokens: previously, we injected an unused variable into the controller function; now, we utilize `dependencies` in the router decorator.

Example usage:
```py
@router.get("/all", dependencies=[Depends(verify_jwt)])
def get_all_attractions(db: Session = Depends(get_db)) -> list[AttractionSchema]:
    return _attraction_service.get_all_attractions(db)
```